### PR TITLE
#3.8 Reusable Cards

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:toonflix/widgets/button.dart';
+import 'package:toonflix/widgets/currency_card.dart';
 
 void main() {
   runApp(const App());
@@ -13,151 +14,121 @@ class App extends StatelessWidget {
     return MaterialApp(
       home: Scaffold(
         backgroundColor: const Color(0xFF181818),
-        body: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: 80),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      const Text(
-                        'Hey, Selena',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 28,
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
-                      Text(
-                        'Welcome back',
-                        style: TextStyle(
-                          color: Colors.white.withValues(alpha: 0.5),
-                          fontSize: 18,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              const SizedBox(height: 120),
-              Text(
-                "Total Balance",
-                style: TextStyle(
-                  fontSize: 22,
-                  color: Colors.white.withValues(alpha: 0.8),
-                ),
-              ),
-              const SizedBox(height: 5),
-              const Text(
-                "\$5 194 382",
-                style: TextStyle(
-                  fontSize: 48,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                ),
-              ),
-              const SizedBox(height: 30),
-              const Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Button(
-                    text: "Transfer",
-                    bgColor: Color(0xFFF1B333),
-                    textColor: Colors.black,
-                  ),
-
-                  Button(
-                    text: "Request",
-                    bgColor: Color(0xFF1F2123),
-                    textColor: Colors.white,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 100),
-              const Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    "Wallets",
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 36,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  Text(
-                    "View All",
-                    style: TextStyle(color: Colors.white70, fontSize: 18),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              Container(
-                clipBehavior: Clip.hardEdge,
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1F2123),
-                  borderRadius: BorderRadius.circular(25),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(30),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      const Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            "Euro",
-                            style: TextStyle(
-                              fontSize: 32,
-                              color: Colors.white,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          SizedBox(height: 10),
-                          Row(
-                            children: [
-                              Text(
-                                '6 428',
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  color: Colors.white,
-                                ),
-                              ),
-                              SizedBox(width: 5),
-                              Text(
-                                'EUR',
-                                style: TextStyle(
-                                  fontSize: 20,
-                                  color: Colors.white70,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      Transform.scale(
-                        scale: 2.2,
-                        child: Transform.translate(
-                          offset: const Offset(-5, 12),
-                          child: const Icon(
-                            size: 88,
-                            Icons.euro_rounded,
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 80),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        const Text(
+                          'Hey, Selena',
+                          style: TextStyle(
                             color: Colors.white,
+                            fontSize: 28,
+                            fontWeight: FontWeight.w800,
                           ),
                         ),
-                      ),
-                    ],
+                        Text(
+                          'Welcome back',
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.5),
+                            fontSize: 18,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 70),
+                Text(
+                  "Total Balance",
+                  style: TextStyle(
+                    fontSize: 22,
+                    color: Colors.white.withValues(alpha: 0.8),
                   ),
                 ),
-              ),
-            ],
+                const SizedBox(height: 5),
+                const Text(
+                  "\$5 194 382",
+                  style: TextStyle(
+                    fontSize: 48,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 30),
+                const Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Button(
+                      text: "Transfer",
+                      bgColor: Color(0xFFF1B333),
+                      textColor: Colors.black,
+                    ),
+
+                    Button(
+                      text: "Request",
+                      bgColor: Color(0xFF1F2123),
+                      textColor: Colors.white,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 100),
+                const Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      "Wallets",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 36,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Text(
+                      "View All",
+                      style: TextStyle(color: Colors.white70, fontSize: 18),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                const CurrencyCard(
+                  name: "Euro",
+                  code: "EUR",
+                  amount: '6 428',
+                  isInverted: false,
+                  icon: Icons.euro_rounded,
+                ),
+                Transform.translate(
+                  offset: const Offset(0, -20),
+                  child: const CurrencyCard(
+                    name: "Bitcoin",
+                    code: "BTC",
+                    amount: '9 785',
+                    isInverted: true,
+                    icon: Icons.currency_bitcoin,
+                  ),
+                ),
+                Transform.translate(
+                  offset: const Offset(0, -40),
+                  child: const CurrencyCard(
+                    name: "Dollar",
+                    code: "USD",
+                    amount: '428',
+                    isInverted: false,
+                    icon: Icons.attach_money_outlined,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/widgets/currency_card.dart
+++ b/lib/widgets/currency_card.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+class CurrencyCard extends StatelessWidget {
+  final String name, code, amount;
+  final IconData icon;
+  final bool isInverted;
+
+  final blackColor = const Color(0xFF1F2123);
+
+  const CurrencyCard({
+    super.key,
+    required this.name,
+    required this.code,
+    required this.amount,
+    required this.icon,
+    required this.isInverted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.hardEdge,
+      decoration: BoxDecoration(
+        color: isInverted ? Colors.white : blackColor,
+        borderRadius: BorderRadius.circular(25),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(30),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  name,
+                  style: TextStyle(
+                    fontSize: 32,
+                    color: isInverted ? blackColor : Colors.white,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    Text(
+                      amount,
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: isInverted ? blackColor : Colors.white,
+                      ),
+                    ),
+                    const SizedBox(width: 5),
+                    Text(
+                      code,
+                      style: TextStyle(
+                        fontSize: 20,
+                        color: isInverted ? blackColor : Colors.white70,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            Transform.scale(
+              scale: 2.2,
+              child: Transform.translate(
+                offset: const Offset(-5, 12),
+                child: Icon(
+                  icon,
+                  size: 88,
+                  color: isInverted ? blackColor : Colors.white,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Reusable Cards

### 화면
<img width="1544" alt="Image" src="https://github.com/user-attachments/assets/517af4c6-95d3-4655-a59c-cf4d79da01b8" />

### 작업 내역
- [x] Card 를 재사용 가능한 Widget 으로 분리
- [x] `SingleChildScrollView` Widget 으로 스크롤 활성화