### PR TITLE
#6.9 Detail Screen

### DIFF
--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+class DetailScreen extends StatelessWidget {
+  final String title, thumb, id;
+
+  const DetailScreen({
+    super.key,
+    required this.title,
+    required this.thumb,
+    required this.id,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        // Shadow Style
+        elevation: 2,
+        shadowColor: Colors.black,
+        surfaceTintColor: Colors.transparent,
+
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.green,
+        title: Text(
+          title,
+          style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w400),
+        ),
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: 50),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                width: 250,
+                clipBehavior: Clip.hardEdge,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(15),
+                  boxShadow: [
+                    const BoxShadow(
+                      blurRadius: 15,
+                      offset: Offset(10, 10),
+                      color: Colors.black45,
+                    ),
+                  ],
+                ),
+                child: Image.network(
+                  thumb,
+                  headers: {'Referer': 'https://comic.naver.com'},
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:toonflix/models/webtoon_model.dart';
 import 'package:toonflix/services/api_service.dart';
+import 'package:toonflix/widgets/webtoon_widget.dart';
 
 class HomeScreen extends StatelessWidget {
   HomeScreen({super.key});
@@ -48,29 +49,10 @@ class HomeScreen extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
       itemBuilder: (context, index) {
         var webtoon = snapshot.data![index];
-        return Column(
-          children: [
-            Container(
-              width: 250,
-              clipBehavior: Clip.hardEdge,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(15),
-                boxShadow: [
-                  const BoxShadow(
-                    blurRadius: 15,
-                    offset: Offset(10, 10),
-                    color: Colors.black45,
-                  ),
-                ],
-              ),
-              child: Image.network(
-                webtoon.thumb,
-                headers: const {'Referer': 'https://comic.naver.com'},
-              ),
-            ),
-            const SizedBox(height: 10),
-            Text(webtoon.title, style: const TextStyle(fontSize: 22)),
-          ],
+        return Webtoon(
+          title: webtoon.title,
+          thumb: webtoon.thumb,
+          id: webtoon.id,
         );
       },
       separatorBuilder: (context, index) => const SizedBox(width: 40),

--- a/lib/widgets/webtoon_widget.dart
+++ b/lib/widgets/webtoon_widget.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:toonflix/screens/detail_screen.dart';
+
+class Webtoon extends StatelessWidget {
+  final String title, thumb, id;
+
+  const Webtoon({
+    super.key,
+    required this.title,
+    required this.thumb,
+    required this.id,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder:
+                (context) => DetailScreen(title: title, thumb: thumb, id: id),
+            fullscreenDialog: true,
+          ),
+        );
+      },
+      child: Column(
+        children: [
+          Container(
+            width: 250,
+            clipBehavior: Clip.hardEdge,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(15),
+              boxShadow: [
+                const BoxShadow(
+                  blurRadius: 15,
+                  offset: Offset(10, 10),
+                  color: Colors.black45,
+                ),
+              ],
+            ),
+            child: Image.network(
+              thumb,
+              headers: {'Referer': 'https://comic.naver.com'},
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(title, style: const TextStyle(fontSize: 22)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 화면
<img width="1426" alt="Image" src="https://github.com/user-attachments/assets/133c35b1-91dd-4fde-a099-27d7fea0c5c5" />

### 작업 내역
- [x] 웹툰 리스트에서 웹툰 클릭 시 웹툰 상세 페이지로 이동
- [x] 페이지 이동 애니메이션에 `fullscreenDialog`를 설정해서 아래서 위로 애니메이션동작 