### PR TITLE
#6.10 Hero

### DIFF
--- a/lib/screens/detail_screen.dart
+++ b/lib/screens/detail_screen.dart
@@ -33,22 +33,25 @@ class DetailScreen extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Container(
-                width: 250,
-                clipBehavior: Clip.hardEdge,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(15),
-                  boxShadow: [
-                    const BoxShadow(
-                      blurRadius: 15,
-                      offset: Offset(10, 10),
-                      color: Colors.black45,
-                    ),
-                  ],
-                ),
-                child: Image.network(
-                  thumb,
-                  headers: {'Referer': 'https://comic.naver.com'},
+              Hero(
+                tag: id,
+                child: Container(
+                  width: 250,
+                  clipBehavior: Clip.hardEdge,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(15),
+                    boxShadow: [
+                      const BoxShadow(
+                        blurRadius: 15,
+                        offset: Offset(10, 10),
+                        color: Colors.black45,
+                      ),
+                    ],
+                  ),
+                  child: Image.network(
+                    thumb,
+                    headers: {'Referer': 'https://comic.naver.com'},
+                  ),
                 ),
               ),
             ],

--- a/lib/widgets/webtoon_widget.dart
+++ b/lib/widgets/webtoon_widget.dart
@@ -26,22 +26,25 @@ class Webtoon extends StatelessWidget {
       },
       child: Column(
         children: [
-          Container(
-            width: 250,
-            clipBehavior: Clip.hardEdge,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(15),
-              boxShadow: [
-                const BoxShadow(
-                  blurRadius: 15,
-                  offset: Offset(10, 10),
-                  color: Colors.black45,
-                ),
-              ],
-            ),
-            child: Image.network(
-              thumb,
-              headers: {'Referer': 'https://comic.naver.com'},
+          Hero(
+            tag: id,
+            child: Container(
+              width: 250,
+              clipBehavior: Clip.hardEdge,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(15),
+                boxShadow: [
+                  const BoxShadow(
+                    blurRadius: 15,
+                    offset: Offset(10, 10),
+                    color: Colors.black45,
+                  ),
+                ],
+              ),
+              child: Image.network(
+                thumb,
+                headers: {'Referer': 'https://comic.naver.com'},
+              ),
             ),
           ),
           const SizedBox(height: 10),


### PR DESCRIPTION
### 화면
<img width="1435" alt="Image" src="https://github.com/user-attachments/assets/9f442909-2df1-4eda-a067-93930ea8eaca" />

### 작업 내역
- [x] 웹툰 리스트에서 웹툰 썸네일 클릭 시 썸네일이 가운데로 이동하면서 상세 페이지가 보여지도록 애니메이션 설정